### PR TITLE
Default disable email service with note in docs explaining rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ hana:
   disable_auth: True
   stt_max_length_encoded: 500000  # Arbitrary limit that is larger than any expected voice command
   tts_max_words: 128  # Arbitrary limit that is longer than any default LLM token limit
+  enable_email: True  # Disabled by default; anyone with access to the API will be able to send emails from the configured address
+
 ```
 It is recommended to generate unique values for configured tokens, these are 32
 bytes in hexadecimal representation.

--- a/docker_overlay/etc/neon/diana.yaml
+++ b/docker_overlay/etc/neon/diana.yaml
@@ -28,3 +28,4 @@ hana:
   fastapi_summary: "HANA (HTTP API for Neon Applications) is the HTTP component of the Device Independent API for Neon Applications (DIANA)"
   stt_max_length_encoded: 500000
   tts_max_words: 128
+  enable_email: False

--- a/neon_hana/mq_service_api.py
+++ b/neon_hana/mq_service_api.py
@@ -26,7 +26,6 @@
 
 import json
 
-from tempfile import mkdtemp
 from time import time
 from typing import Optional, Dict, Any, List
 from uuid import uuid4
@@ -48,6 +47,7 @@ class MQServiceManager:
         self.mq_cliend_id = config.get('mq_client_id') or str(uuid4())
         self.stt_max_length = config.get('stt_max_length_encoded') or 500000
         self.tts_max_words = config.get('tts_max_words') or 128
+        self.email_enabled = config.get('enable_email')
 
     def _validate_api_proxy_response(self, response: dict):
         if response['status_code'] == 200:
@@ -88,6 +88,8 @@ class MQServiceManager:
 
     def send_email(self, recipient: str, subject: str, body: str,
                    attachments: Optional[Dict[str, str]]):
+        if not self.email_enabled:
+            raise APIError(status_code=503, detail="Email service disabled")
         request_data = {"recipient": recipient,
                         "subject": subject,
                         "body": body,


### PR DESCRIPTION
# Description
This adds an option to disable the email service because anyone with access to the API would be able to send an email from the configured email address with any attachments/email contents

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
The email proxy service should do some kind of validation of email contents to prevent abuse, but it must allow for skills to reasonably use the email service. Consider also imposing stricter rate limits as emails are sent infrequently under normal circumstances