### PR TITLE
JWT server cache fix and client response update

### DIFF
--- a/neon_hana/app/routers/auth.py
+++ b/neon_hana/app/routers/auth.py
@@ -24,7 +24,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from neon_hana.app.dependencies import client_manager
 from neon_hana.schema.auth_requests import *
@@ -33,8 +33,10 @@ auth_route = APIRouter(prefix="/auth", tags=["authentication"])
 
 
 @auth_route.post("/login")
-async def check_login(request: AuthenticationRequest) -> AuthenticationResponse:
-    return client_manager.check_auth_request(**dict(request))
+async def check_login(auth_request: AuthenticationRequest,
+                      request: Request) -> AuthenticationResponse:
+    return client_manager.check_auth_request(**dict(auth_request),
+                                             origin_ip=request.client.host)
 
 
 @auth_route.post("/refresh")

--- a/neon_hana/auth/client_manager.py
+++ b/neon_hana/auth/client_manager.py
@@ -63,7 +63,8 @@ class ClientManager:
                 "expiration": token_expiration}
 
     def check_auth_request(self, client_id: str, username: str,
-                           password: Optional[str], origin_ip: str):
+                           password: Optional[str] = None,
+                           origin_ip: str = "127.0.0.1"):
         if client_id in self.authorized_clients:
             print(f"Using cached client: {self.authorized_clients[client_id]}")
             return self.authorized_clients[client_id]

--- a/neon_hana/schema/auth_requests.py
+++ b/neon_hana/schema/auth_requests.py
@@ -27,13 +27,13 @@
 from typing import Optional
 from uuid import uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class AuthenticationRequest(BaseModel):
     username: str = "guest"
     password: Optional[str] = None
-    client_id: str = str(uuid4())
+    client_id: str = Field(default_factory=lambda: str(uuid4()))
 
     model_config = {
         "json_schema_extra": {

--- a/neon_hana/schema/auth_requests.py
+++ b/neon_hana/schema/auth_requests.py
@@ -48,6 +48,7 @@ class AuthenticationResponse(BaseModel):
     client_id: str
     access_token: str
     refresh_token: str
+    expiration: float
 
     model_config = {
         "json_schema_extra": {
@@ -55,7 +56,8 @@ class AuthenticationResponse(BaseModel):
                 "username": "guest",
                 "client_id": "be84ae66-f61c-4aac-a9af-b0da364b82b6",
                 "access_token": "<redacted>",
-                "refresh_token": "<redacted>"
+                "refresh_token": "<redacted>",
+                "expiration": 1706045776.4168212
             }]}}
 
 


### PR DESCRIPTION
# Description
Prevent caching incomplete jwt tokens in `validate_auth` method
Add token expiration to response data so client can manage refreshing
Fix bug causing all clients to use the same default client_id
Adds rate limit by IP address to `auth/login` endpoint

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Resolves an error causing `500` returns to clients requesting auth after a server restart