### PR TITLE
Update to use client-provided public IP address when available

### DIFF
--- a/neon_hana/app/routers/assist.py
+++ b/neon_hana/app/routers/assist.py
@@ -46,5 +46,6 @@ async def get_tts(request: TTSRequest) -> TTSResponse:
 @assist_route.post("/get_response")
 async def get_response(skill_request: SkillRequest,
                        request: Request) -> SkillResponse:
-    skill_request.node_data.networking.public_ip = request.client.host
+    if not skill_request.node_data.networking.public_ip:
+        skill_request.node_data.networking.public_ip = request.client.host
     return mq_connector.get_response(**dict(skill_request))


### PR DESCRIPTION
# Description
Allows for a client to specify a public IP address instead of always reading from the incoming request. This allows for specifying an actual public address when the client and server run on the same network to better match behavior of Neon running on-device.

# Issues
Follow-up to #11 

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->