### PR TITLE
Add `lang_code` optional param to weather endpoint

### DIFF
--- a/neon_hana/app/routers/api_proxy.py
+++ b/neon_hana/app/routers/api_proxy.py
@@ -36,6 +36,7 @@ proxy_route = APIRouter(prefix="/proxy", tags=["backend"],
 
 @proxy_route.post("/weather")
 async def api_proxy_weather(query: WeatherAPIRequest) -> WeatherAPIOnecallResponse:
+    query["lang"] = query.pop("lang_code")
     return mq_connector.query_api_proxy("open_weather_map", dict(query))
 
 

--- a/neon_hana/app/routers/api_proxy.py
+++ b/neon_hana/app/routers/api_proxy.py
@@ -36,8 +36,9 @@ proxy_route = APIRouter(prefix="/proxy", tags=["backend"],
 
 @proxy_route.post("/weather")
 async def api_proxy_weather(query: WeatherAPIRequest) -> WeatherAPIOnecallResponse:
+    query = dict(query)
     query["lang"] = query.pop("lang_code")
-    return mq_connector.query_api_proxy("open_weather_map", dict(query))
+    return mq_connector.query_api_proxy("open_weather_map", query)
 
 
 @proxy_route.post("/stock/symbol")

--- a/neon_hana/schema/api_requests.py
+++ b/neon_hana/schema/api_requests.py
@@ -34,7 +34,7 @@ class WeatherAPIRequest(BaseModel):
     lat: float
     lon: float
     unit: str = "metric"
-
+    lang_code: str = "en"
     model_config = {
         "json_schema_extra": {
             "examples": [{
@@ -42,11 +42,12 @@ class WeatherAPIRequest(BaseModel):
                         "lat": 47.6815,
                         "lon": -122.2087,
                         "unit": "imperial",
+                        "lang_code": "en"
                     }, {
                         "api": "onecall",
                         "lat": 47.6815,
                         "lon": -122.2087,
-                        "unit": "metric",
+                        "unit": "metric"
                     }]}}
 
 


### PR DESCRIPTION
# Description
Add `lang_code` option to weather endpoint
Replaces `lang_code` with `lang` for api consistency and OWM compat.

# Issues
Closes #15

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->