### PR TITLE
Add endpoints for public IP address and request header debugging

### DIFF
--- a/neon_hana/app/__init__.py
+++ b/neon_hana/app/__init__.py
@@ -32,6 +32,7 @@ from neon_hana.app.routers.assist import assist_route
 from neon_hana.app.routers.llm import llm_route
 from neon_hana.app.routers.mq_backend import mq_route
 from neon_hana.app.routers.auth import auth_route
+from neon_hana.app.routers.util import util_route
 from neon_hana.version import __version__
 
 
@@ -45,5 +46,6 @@ def create_app(config: dict):
     app.include_router(proxy_route)
     app.include_router(mq_route)
     app.include_router(llm_route)
+    app.include_router(util_route)
 
     return app

--- a/neon_hana/app/routers/util.py
+++ b/neon_hana/app/routers/util.py
@@ -25,13 +25,14 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from fastapi import APIRouter, Request
+from starlette.responses import PlainTextResponse
 
 from neon_hana.app.dependencies import client_manager
 
 util_route = APIRouter(prefix="/util", tags=["utilities"])
 
 
-@util_route.get("/client_ip")
+@util_route.get("/client_ip", response_class=PlainTextResponse)
 async def api_client_ip(request: Request) -> str:
     client_manager.validate_auth("", request.client.host)
     return request.client.host

--- a/neon_hana/app/routers/util.py
+++ b/neon_hana/app/routers/util.py
@@ -25,16 +25,19 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from fastapi import APIRouter, Request
-from starlette.datastructures import Headers
+
+from neon_hana.app.dependencies import client_manager
 
 util_route = APIRouter(prefix="/util", tags=["utilities"])
 
 
 @util_route.get("/client_ip")
 async def api_client_ip(request: Request) -> str:
+    client_manager.validate_auth("", request.client.host)
     return request.client.host
 
 
 @util_route.get("/headers")
-async def api_headers(request: Request) -> Headers:
+async def api_headers(request: Request):
+    client_manager.validate_auth("", request.client.host)
     return request.headers

--- a/neon_hana/app/routers/util.py
+++ b/neon_hana/app/routers/util.py
@@ -24,23 +24,17 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import uvicorn
-from os import environ
+from fastapi import APIRouter, Request
+from starlette.datastructures import Headers
 
-environ.setdefault("OVOS_CONFIG_BASE_FOLDER", "neon")
-environ.setdefault("OVOS_CONFIG_FILENAME", "diana.yaml")
-
-from ovos_config.config import Configuration
-
-from neon_hana.app import create_app
+util_route = APIRouter(prefix="/util", tags=["utilities"])
 
 
-def main():
-    config = Configuration().get("hana", {})
-    app = create_app(config)
-    uvicorn.run(app, host=config.get('server_host', "0.0.0.0"),
-                port=config.get('port', 8080), forwarded_allow_ips="*")
+@util_route.get("/client_ip")
+async def api_client_ip(request: Request) -> str:
+    return request.client.host
 
 
-if __name__ == "__main__":
-    main()
+@util_route.get("/headers")
+async def api_headers(request: Request) -> Headers:
+    return request.headers

--- a/neon_hana/auth/client_manager.py
+++ b/neon_hana/auth/client_manager.py
@@ -132,7 +132,7 @@ class ClientManager:
                                                      max_tokens=self._rpm))
         if not self.rate_limiter.consume(origin_ip) and self._rpm > 0:
             raise HTTPException(status_code=429,
-                                detail=f"Requests limited to {self._rpm}/min"
+                                detail=f"Requests limited to {self._rpm}/min "
                                        f"per client connection")
 
         if self._disable_auth:


### PR DESCRIPTION
# Description
Add `util` router with `client_ip` and `headers` endpoints for connection debugging
Allows all forwarded IPs to get real client IP address instead of proxy IP

# Issues
Relates to https://github.com/OpenVoiceOS/ovos-PHAL-plugin-ipgeo/issues/12

# Other Notes
Currently deployed at hana.neonaialpha.com for testing