### PR TITLE
Work around occasional OWM API errors

### DIFF
--- a/neon_hana/schema/api_responses.py
+++ b/neon_hana/schema/api_responses.py
@@ -34,7 +34,7 @@ class WeatherAPIOnecallResponse(BaseModel):
     timezone: str
     timezone_offset: int
     current: Dict[str, Any]
-    minutely: List[dict]
+    minutely: Optional[List[dict]]
     hourly: List[dict]
     daily: List[dict]
 


### PR DESCRIPTION
# Description
Mark minutely weather response data as optional

# Issues
Closes #28 

# Other Notes
The [API docs](https://openweathermap.org/api/one-call-3#parameter) indicate the `minutely` data should always be present in a response, but in practice it is sometimes missing. Neon does not currently use this part of the response, so HANA will now treat it as optional.