### PR TITLE
Resolve bugs noted in Beta deployment

### DIFF
--- a/neon_hana/auth/client_manager.py
+++ b/neon_hana/auth/client_manager.py
@@ -52,7 +52,8 @@ _DEFAULT_USER_PERMISSIONS = PermissionsConfig(klat=AccessRoles.USER,
                                               diana=AccessRoles.USER,
                                               node=AccessRoles.USER,
                                               hub=AccessRoles.USER,
-                                              llm=AccessRoles.USER)
+                                              llm=AccessRoles.USER,
+                                              users=AccessRoles.NONE)
 
 
 class ClientManager:
@@ -274,6 +275,10 @@ class ClientManager:
         except ExpiredSignatureError:
             raise HTTPException(status_code=401,
                                 detail="Refresh token is expired")
+        except ValidationError:
+            raise HTTPException(status_code=400,
+                                detail=f"Invalid token data received from "
+                                       f"client: {client_id}.")
         if refresh_data.jti != token_data.jti + ".refresh":
             raise HTTPException(status_code=403,
                                 detail="Refresh and access token mismatch")


### PR DESCRIPTION
# Description
Add default permissions for `users` to address serialization bug
Explicitly handle old refresh tokens which fail Pydantic validation

# Issues
Includes a change to default user permissions to mitigate a serialization issue fixed in https://github.com/NeonGeckoCom/neon-data-models/pull/10

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->