### PR TITLE
Handle empty API proxy responses

### DIFF
--- a/neon_hana/mq_service_api.py
+++ b/neon_hana/mq_service_api.py
@@ -57,6 +57,11 @@ class MQServiceManager:
 
     @staticmethod
     def _validate_api_proxy_response(response: dict, query_params: dict):
+        response.setdefault('content',
+                            {"error": "No response content was received",
+                             "raw_response": response,
+                             "raw_query": query_params})
+        response.setdefault('status_code', 500)
         if response['status_code'] == 200:
             try:
                 resp = json.loads(response['content'])


### PR DESCRIPTION
# Description
Set default values in `validate_api_proxy_response` to include more details in error responses to clients

# Issues
Addresses uncaught exception logged in https://neon-ai.sentry.io/issues/6302853101/events/fefd6b7410644e9bacab910f6349bd00/

# Other Notes
Deployed and tested in the `alpha` namespace