### PR TITLE
Deprecate pocketsphinx WW Support

### DIFF
--- a/requirements/streaming.txt
+++ b/requirements/streaming.txt
@@ -1,7 +1,7 @@
 mock~=5.0
 ovos-dinkum-listener~=0.1
 ovos-vad-plugin-webrtcvad~=0.0.1
-ovos-ww-plugin-pocketsphinx~=0.1
+#ovos-ww-plugin-pocketsphinx~=0.1
 ovos-ww-plugin-vosk~=0.1
 ovos-ww-plugin-precise-lite[tflite]~=0.1
 ovos-ww-plugin-precise~=0.1


### PR DESCRIPTION
# Description
Removes pocketsphinx from streaming dependencies and default Docker build

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Upstream [pocketsphinx plugin](https://github.com/OpenVoiceOS/ovos-ww-plugin-pocketsphinx) is archived and no longer maintained. Compatibility has broken with recent Docker base images