### PR TITLE
Resolve errors around LLM inference endpoints

### DIFF
--- a/neon_hana/auth/client_manager.py
+++ b/neon_hana/auth/client_manager.py
@@ -440,7 +440,7 @@ class UserTokenAuth(HTTPBearer):
         self.client_manager = client_manager
 
     async def __call__(self, request: Request):
-        credentials: HTTPAuthorizationCredentials = \
+        credentials: Optional[HTTPAuthorizationCredentials] = \
             await HTTPBearer.__call__(self, request)
         if credentials:
             if not credentials.scheme == "Bearer":

--- a/neon_hana/mq_service_api.py
+++ b/neon_hana/mq_service_api.py
@@ -31,6 +31,7 @@ from time import time
 from typing import Optional, Dict, Any, List, Tuple, Union
 from uuid import uuid4
 from fastapi import HTTPException
+from pydantic import ValidationError
 from neon_data_models.models.api.llm import LLMResponse
 from neon_data_models.models.api.mq.brainforge import LLMGetPersonasResponse
 from neon_data_models.models.api.http.brainforge import LLMGetModelsHttpResponse, LLMGetPersonasHttpResponse, \
@@ -362,10 +363,16 @@ class AsyncMqServiceManager:
             f"{request.llm_name}@{request.llm_revision}"
         request_data = request.model_dump()
         request_data["user_id"] = user_id
+        # Timeout set arbitrarily high to allow for long LLM responses
         response = await self._send_mq_request_async("/brainforge", request_data,
                                    "brainforge_get_inference",
-                                   timeout=self.mq_default_timeout)
-        return LLMResponse(**response)
+                                   timeout=300)
+        try:
+            return LLMResponse(**response)
+        except ValidationError as e:
+            raise APIError(
+                    status_code=500,
+                    detail=f"Invalid response from Brainforge: {response}") from e
 
     async def get_skills_api(self):
         request_data = {"msg_type": "neon.skill_api.get",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,7 +129,7 @@ class TestHanaApp(TestCase):
         response = self.test_app.post("/neon/get_stt",
                                       json={"encoded_audio": "MOCK_B64_AUDIO",
                                             "lang_code": "en-us"})
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -155,7 +155,7 @@ class TestHanaApp(TestCase):
         response = self.test_app.post("/neon/get_tts",
                                       json={"to_speak": "test",
                                             "lang_code": "en-us"})
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -183,7 +183,7 @@ class TestHanaApp(TestCase):
         response = self.test_app.post("/neon/get_response",
                                       json={"utterance": "test",
                                             "lang_code": "en-us"})
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -220,7 +220,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/proxy/weather",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -250,7 +250,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/proxy/stock/symbol",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -280,7 +280,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/proxy/stock/quote",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -319,7 +319,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/proxy/geolocation/geocode",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -356,7 +356,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/proxy/geolocation/reverse",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -384,7 +384,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/proxy/wolframalpha",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -411,7 +411,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/email",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -447,7 +447,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/metrics/upload",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -471,7 +471,7 @@ class TestHanaApp(TestCase):
         # Invalid missing auth
         response = self.test_app.post("/ccl/parse",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         # Invalid request
         self.assertEqual(self.test_app.post(
@@ -493,7 +493,7 @@ class TestHanaApp(TestCase):
 
         # Invalid missing auth
         response = self.test_app.post("/coupons")
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
     @patch("neon_hana.mq_service_api.send_mq_request")
     def test_llm(self, send_request):
@@ -540,7 +540,7 @@ class TestHanaApp(TestCase):
         # Invalid requests
         response = self.test_app.post("/llm/chatgpt",
                                       json=valid_request)
-        self.assertEqual(response.status_code, 403, response.text)
+        self.assertIn(response.status_code, [401, 403], response.text)
 
         response = self.test_app.post("/llm/chatgpt",
                                       headers={"Authorization": f"Bearer {token}"})


### PR DESCRIPTION
# Description
Extend LLM inference timeout to 5 minutes
Add exception handling around LLM endpoints
Updates unit tests for compat. with FastAPI token error responses
Fixes linter type annotation bug

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->