### PR TITLE
feat: add hub identity endpoint (CO1 2.3)

### DIFF
--- a/neon_hana/app/__init__.py
+++ b/neon_hana/app/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2026 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -35,13 +35,14 @@ from neon_hana.app.routers.mq_backend import mq_route
 from neon_hana.app.routers.auth import auth_route
 from neon_hana.app.routers.user import user_route
 from neon_hana.app.routers.util import util_route
+from neon_hana.app.routers.hub import hub_route
 from neon_hana.app.routers.node_server import node_route, socket_api
 from neon_hana.version import __version__
 
 
 def create_app(config: dict):
-    title = config.get('fastapi_title') or "HANA: HTTP API for Neon Applications"
-    summary = config.get('fastapi_summary') or ""
+    title = config.get("fastapi_title") or "HANA: HTTP API for Neon Applications"
+    summary = config.get("fastapi_summary") or ""
     version = __version__
     app = FastAPI(title=title, summary=summary, version=version)
     app.include_router(auth_route)
@@ -53,7 +54,7 @@ def create_app(config: dict):
     app.include_router(node_route)
     app.include_router(user_route)
     app.include_router(bf_route)
-
+    app.include_router(hub_route)
 
     @app.get("/status")
     def get_status():
@@ -61,15 +62,11 @@ def create_app(config: dict):
         Get service status
         """
         if not client_manager.check_health():
-            return Response(status_code=500,
-                            content="Client manager is not healthy")
+            return Response(status_code=500, content="Client manager is not healthy")
         if not mq_connector.check_health():
-            return Response(status_code=500,
-                            content="MQ Connector is not healthy")
+            return Response(status_code=500, content="MQ Connector is not healthy")
         if socket_api and not socket_api.check_health():
-            return Response(status_code=500,
-                            content="Websocket API is not healthy")
+            return Response(status_code=500, content="Websocket API is not healthy")
         return Response(status_code=200, content="Ready")
-
 
     return app

--- a/neon_hana/app/routers/hub.py
+++ b/neon_hana/app/routers/hub.py
@@ -1,0 +1,82 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2026 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from fastapi import APIRouter, Depends
+from ovos_config.config import update_mycroft_config
+from ovos_utils.log import LOG
+
+from neon_hana.app.dependencies import config, jwt_bearer
+from neon_hana.hub_id import generate_hub_id
+from neon_hana.schema.hub_requests import HubIdentityResponse, UpdateHubIdentityRequest
+from neon_hana.version import __version__
+
+hub_route = APIRouter(prefix="/hub", tags=["hub"])
+
+# Generate hub_id eagerly at import time to avoid a race condition
+# where two concurrent first-boot requests each generate a different ID.
+_hub_id = config.get("hub_id")
+if not _hub_id:
+    _hub_id = generate_hub_id()
+    LOG.info("Generated new hub_id: %s", _hub_id)
+    update_mycroft_config({"hana": {"hub_id": _hub_id}})
+    config["hub_id"] = _hub_id
+
+
+@hub_route.get("/identity")
+async def get_hub_identity() -> HubIdentityResponse:
+    """
+    Get the identity of this Hub.
+
+    Returns a stable hub ID, user-configurable display name, and
+    software version. This endpoint is public (no authentication
+    required) so that Nodes can identify a Hub during discovery.
+    """
+    display_name = config.get("hub_display_name") or "Neon Hub"
+    return HubIdentityResponse(
+        hub_id=_hub_id,
+        display_name=display_name,
+        version=__version__,
+    )
+
+
+@hub_route.post("/identity", dependencies=[Depends(jwt_bearer)])
+async def update_hub_identity(
+    request: UpdateHubIdentityRequest,
+) -> HubIdentityResponse:
+    """
+    Update the display name of this Hub.
+
+    Requires authentication. The new display name is persisted to
+    the configuration file and survives container restarts.
+    """
+    update_mycroft_config({"hana": {"hub_display_name": request.display_name}})
+    config["hub_display_name"] = request.display_name
+    LOG.info("Hub display_name updated to: %s", request.display_name)
+    return HubIdentityResponse(
+        hub_id=_hub_id,
+        display_name=request.display_name,
+        version=__version__,
+    )

--- a/neon_hana/hub_id.py
+++ b/neon_hana/hub_id.py
@@ -1,0 +1,84 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2026 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Generate memorable, Docker-style hub identifiers.
+
+Produces kebab-case names like "bright-silver-falcon" or
+"calm-amber-river-stone" that are easier to remember than UUIDs
+when a user needs to identify which Hub they're connected to.
+"""
+
+import secrets
+
+# 82 adjectives — evocative, whimsical, deliberately nonsequitur
+# paired with tech nouns for maximum personality.
+# Pruned: adjectives that are too specifically plant/terrain
+# (mossy, pine, cedar, fern, oaken, marsh, timber, willow, rowan, etc.)
+# The test: does "[adjective]-synapse" sound cool or silly?
+_ADJECTIVES = [
+    "ancient", "amber", "arctic", "azure", "bold", "brave", "bright",
+    "bronze", "calm", "clear", "clever", "cobalt", "coral", "cosmic",
+    "crisp", "crystal", "daring", "dawn", "deep", "eager", "ember",
+    "fair", "fierce", "frost", "gentle", "gilded", "glad", "golden",
+    "grand", "hidden", "hollow", "iron", "ivory", "jade", "keen",
+    "kind", "lapis", "light", "lilac", "lively", "lunar", "marble",
+    "merry", "noble", "north", "onyx", "opal", "pale", "pearl",
+    "plain", "plum", "polar", "proud", "quiet", "rapid", "ruby",
+    "scarlet", "serene", "shadow", "sharp", "silent", "silver", "slate",
+    "solar", "south", "steady", "steel", "still", "storm", "sunny",
+    "swift", "tawny", "teal", "tender", "topaz", "true", "velvet",
+    "vivid", "warm", "west", "wild", "wise",
+]
+
+# 73 nouns — AI, computing, science, engineering
+_NOUNS = [
+    "agent", "array", "aurora", "batch", "beacon", "cache", "charge",
+    "cipher", "circuit", "codec", "coil", "core", "cortex", "diode",
+    "echo", "epoch", "field", "flux", "forge", "gate", "glyph",
+    "graph", "grid", "helix", "index", "kernel", "laser", "lattice",
+    "lens", "link", "loom", "matrix", "mesh", "model", "modem",
+    "neuron", "nexus", "node", "optic", "orbit", "parse", "patch",
+    "phase", "photon", "pixel", "plasma", "probe", "prism", "pulse",
+    "qubit", "radar", "relay", "rotor", "scope", "servo", "shard",
+    "signal", "socket", "sonar", "spark", "stack", "switch", "sync",
+    "synapse", "tensor", "token", "trace", "valve", "vector", "vertex",
+    "voxel", "watt", "wave",
+]
+
+
+_rng = secrets.SystemRandom()
+
+
+def generate_hub_id() -> str:
+    """Generate a three-word kebab-case identifier.
+
+    Format: adjective-adjective-noun (adjectives are always distinct)
+    Combinatorial space: 82 * 81 * 73 ≈ 485K unique IDs.
+    Collision probability is negligible for home networks.
+    """
+    adj1, adj2 = _rng.sample(_ADJECTIVES, 2)
+    noun = _rng.choice(_NOUNS)
+    return f"{adj1}-{adj2}-{noun}"

--- a/neon_hana/schema/hub_requests.py
+++ b/neon_hana/schema/hub_requests.py
@@ -1,0 +1,71 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2026 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class HubIdentityResponse(BaseModel):
+    """Response model for GET /hub/identity."""
+
+    hub_id: str = Field(description="Stable, human-readable hub identifier (e.g. 'bright-silver-falcon')")
+    display_name: str = Field(description="User-configurable display name for this hub")
+    version: str = Field(description="HANA software version")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "hub_id": "bright-silver-falcon",
+                    "display_name": "Neon Hub (Office)",
+                    "version": "0.1.1a21",
+                }
+            ]
+        }
+    }
+
+
+class UpdateHubIdentityRequest(BaseModel):
+    """Request model for POST /hub/identity."""
+
+    display_name: str = Field(min_length=1, max_length=128, description="New display name for this hub")
+
+    @field_validator("display_name")
+    @classmethod
+    def strip_and_validate(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("display_name must not be blank")
+        return v
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "display_name": "Kitchen Hub",
+                }
+            ]
+        }
+    }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -568,4 +568,109 @@ class TestHanaApp(TestCase):
         for key, val in test_headers.items():
             self.assertEqual(response.json()[key.lower()], val, response.json())
 
+    def test_hub_identity_get(self):
+        # Public endpoint, no auth required
+        response = self.test_app.get("/hub/identity")
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertTrue(data["hub_id"], "hub_id should be non-empty")
+
+    def test_hub_identity_stable(self):
+        # hub_id must not change across calls
+        id1 = self.test_app.get("/hub/identity").json()["hub_id"]
+        id2 = self.test_app.get("/hub/identity").json()["hub_id"]
+        id3 = self.test_app.get("/hub/identity").json()["hub_id"]
+        self.assertEqual(id1, id2)
+        self.assertEqual(id2, id3)
+
+    @patch("neon_hana.app.routers.hub.update_mycroft_config")
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_hub_identity_update(self, send_request, mock_config_write):
+        token = self._get_tokens()["access_token"]
+        original = self.test_app.get("/hub/identity").json()
+
+        # Valid update
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "Kitchen Hub"},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data["display_name"], "Kitchen Hub")
+        self.assertEqual(data["hub_id"], original["hub_id"])
+        mock_config_write.assert_called()
+
+        # Verify persistence in memory
+        data = self.test_app.get("/hub/identity").json()
+        self.assertEqual(data["display_name"], "Kitchen Hub")
+
+        # Whitespace is stripped from valid input
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "  Living Room Hub  "},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.json()["display_name"], "Living Room Hub")
+
+        # Boundary: 1-char name accepted
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "X"},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 200, response.text)
+
+        # Boundary: 128-char name accepted
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "x" * 128},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 200, response.text)
+
+        # Restore default to avoid test ordering issues
+        from neon_hana.app.dependencies import config
+        config.pop("hub_display_name", None)
+
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_hub_identity_update_auth_required(self, send_request):
+        # Missing auth
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "No Auth Hub"})
+        self.assertIn(response.status_code, [401, 403], response.text)
+
+    @patch("neon_hana.app.routers.hub.update_mycroft_config")
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_hub_identity_update_validation(self, send_request,
+                                            mock_config_write):
+        token = self._get_tokens()["access_token"]
+
+        # Empty display_name
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": ""},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Whitespace-only display_name
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "   "},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Too long display_name
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "x" * 129},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Missing body
+        response = self.test_app.post(
+            "/hub/identity",
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Config was never written for invalid requests
+        mock_config_write.assert_not_called()
+
 # TODO: Define node endpoint tests

--- a/tests/test_hub_id.py
+++ b/tests/test_hub_id.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from neon_hana.hub_id import generate_hub_id, _ADJECTIVES, _NOUNS
+
+
+class TestHubIdGenerator(TestCase):
+    def test_words_from_lists(self):
+        hub_id = generate_hub_id()
+        adj1, adj2, noun = hub_id.split("-")
+        self.assertIn(adj1, _ADJECTIVES, f"{adj1} not in adjectives")
+        self.assertIn(adj2, _ADJECTIVES, f"{adj2} not in adjectives")
+        self.assertIn(noun, _NOUNS, f"{noun} not in nouns")
+
+    def test_adjectives_always_distinct(self):
+        for _ in range(5):
+            adj1, adj2, _ = generate_hub_id().split("-")
+            self.assertNotEqual(adj1, adj2,
+                                "Both adjective slots drew the same word")
+
+    def test_no_duplicates_in_word_lists(self):
+        self.assertEqual(len(_ADJECTIVES), len(set(_ADJECTIVES)),
+                         "Duplicate adjectives found")
+        self.assertEqual(len(_NOUNS), len(set(_NOUNS)),
+                         "Duplicate nouns found")


### PR DESCRIPTION
GET /hub/identity returns a stable hub ID, user-configurable display name, and HANA version. The hub ID is a memorable three-word kebab-case identifier (e.g. "bold-crystal-synapse") generated eagerly at startup and persisted to config.

POST /hub/identity (auth required) allows updating the display name, which is stripped of whitespace and validated for length.

The GET endpoint is intentionally public (no auth) so Nodes can identify a Hub during network discovery.
