### PR TITLE
feat: hub identity and config endpoints (CO1 2.3, 2.4)

### DIFF
--- a/neon_hana/app/__init__.py
+++ b/neon_hana/app/__init__.py
@@ -1,6 +1,6 @@
 # NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
 # All trademark and other rights reserved by their respective owners
-# Copyright 2008-2021 Neongecko.com Inc.
+# Copyright 2008-2026 Neongecko.com Inc.
 # BSD-3
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -35,13 +35,14 @@ from neon_hana.app.routers.mq_backend import mq_route
 from neon_hana.app.routers.auth import auth_route
 from neon_hana.app.routers.user import user_route
 from neon_hana.app.routers.util import util_route
+from neon_hana.app.routers.hub import hub_route
 from neon_hana.app.routers.node_server import node_route, socket_api
 from neon_hana.version import __version__
 
 
 def create_app(config: dict):
-    title = config.get('fastapi_title') or "HANA: HTTP API for Neon Applications"
-    summary = config.get('fastapi_summary') or ""
+    title = config.get("fastapi_title") or "HANA: HTTP API for Neon Applications"
+    summary = config.get("fastapi_summary") or ""
     version = __version__
     app = FastAPI(title=title, summary=summary, version=version)
     app.include_router(auth_route)
@@ -53,7 +54,7 @@ def create_app(config: dict):
     app.include_router(node_route)
     app.include_router(user_route)
     app.include_router(bf_route)
-
+    app.include_router(hub_route)
 
     @app.get("/status")
     def get_status():
@@ -61,15 +62,11 @@ def create_app(config: dict):
         Get service status
         """
         if not client_manager.check_health():
-            return Response(status_code=500,
-                            content="Client manager is not healthy")
+            return Response(status_code=500, content="Client manager is not healthy")
         if not mq_connector.check_health():
-            return Response(status_code=500,
-                            content="MQ Connector is not healthy")
+            return Response(status_code=500, content="MQ Connector is not healthy")
         if socket_api and not socket_api.check_health():
-            return Response(status_code=500,
-                            content="Websocket API is not healthy")
+            return Response(status_code=500, content="Websocket API is not healthy")
         return Response(status_code=200, content="Ready")
-
 
     return app

--- a/neon_hana/app/routers/hub.py
+++ b/neon_hana/app/routers/hub.py
@@ -24,14 +24,28 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+from typing import Optional
+
+import yaml
 from fastapi import APIRouter, Depends
 from ovos_config.config import update_mycroft_config
 from ovos_utils.log import LOG
 
 from neon_hana.app.dependencies import config, jwt_bearer
 from neon_hana.hub_id import generate_hub_id
-from neon_hana.schema.hub_requests import HubIdentityResponse, UpdateHubIdentityRequest
+from neon_hana.schema.hub_requests import (
+    HubConfigResponse,
+    HubIdentityResponse,
+    LLMConfig,
+    STTConfig,
+    TTSConfig,
+    UpdateHubIdentityRequest,
+)
 from neon_hana.version import __version__
+
+_DEFAULT_TTS_MODULE = "neon-tts-plugin-coqui"
+_DEFAULT_STT_MODULE = "neon-stt-plugin-nemo"
 
 hub_route = APIRouter(prefix="/hub", tags=["hub"])
 
@@ -79,4 +93,62 @@ async def update_hub_identity(
         hub_id=_hub_id,
         display_name=request.display_name,
         version=__version__,
+    )
+
+
+def _read_neon_yaml() -> Optional[dict]:
+    """Read neon.yaml from the XDG config path.
+
+    Returns the parsed config dict, or None if the file is missing or
+    unreadable (e.g. HANA running outside a Hub deployment, permission
+    issues, or malformed YAML).
+    """
+    xdg_config = os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+    neon_yaml_path = os.path.join(xdg_config, "neon", "neon.yaml")
+    try:
+        with open(neon_yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        LOG.info("neon.yaml not found at %s", neon_yaml_path)
+        return None
+    except (PermissionError, IsADirectoryError, yaml.YAMLError) as e:
+        LOG.warning("Failed to read neon.yaml at %s: %s", neon_yaml_path, e)
+        return None
+    if not isinstance(data, dict):
+        LOG.warning("neon.yaml at %s is not a mapping (got %s); ignoring",
+                     neon_yaml_path, type(data).__name__)
+        return None
+    return data
+
+
+@hub_route.get("/config")
+async def get_hub_config() -> HubConfigResponse:
+    """
+    Get the active configuration of this Hub.
+
+    Returns the currently configured TTS, STT, and LLM engines.
+    TTS/STT are read from neon.yaml on each request so that
+    config changes are reflected without restarting HANA.
+    If the file is not present (non-Hub deployment), those
+    fields are null. If present but the keys are not set,
+    known defaults are returned.
+
+    This endpoint is public (no authentication required) so that
+    Nodes can display Hub configuration during discovery.
+    """
+    neon_config = _read_neon_yaml()
+
+    if neon_config is None:
+        tts = None
+        stt = None
+    else:
+        tts_module = (neon_config.get("tts") or {}).get("module", _DEFAULT_TTS_MODULE)
+        stt_module = (neon_config.get("stt") or {}).get("module", _DEFAULT_STT_MODULE)
+        tts = TTSConfig(module=tts_module)
+        stt = STTConfig(module=stt_module)
+
+    return HubConfigResponse(
+        tts=tts,
+        stt=stt,
+        llm=LLMConfig(name="Neon Classic"),
     )

--- a/neon_hana/app/routers/hub.py
+++ b/neon_hana/app/routers/hub.py
@@ -29,6 +29,7 @@ from typing import Optional
 
 import yaml
 from fastapi import APIRouter, Depends
+from neon_data_models.models.api.llm import LLMPersona
 from ovos_config.config import update_mycroft_config
 from ovos_utils.log import LOG
 
@@ -37,7 +38,6 @@ from neon_hana.hub_id import generate_hub_id
 from neon_hana.schema.hub_requests import (
     HubConfigResponse,
     HubIdentityResponse,
-    LLMConfig,
     STTConfig,
     TTSConfig,
     UpdateHubIdentityRequest,
@@ -136,6 +136,11 @@ async def get_hub_config() -> HubConfigResponse:
     This endpoint is public (no authentication required) so that
     Nodes can display Hub configuration during discovery.
     """
+    # TODO: This relies on HANA sharing a local FS with the core services
+    # (true for a standard Hub deployment, not for split/cloud deployments).
+    # When opm.tts.query / opm.stt.query are reliably handled by ovos-audio
+    # / neon-speech, fall back to messagebus queries via MQ for non-Hub
+    # deployments. See the related research note in the project tracker.
     neon_config = _read_neon_yaml()
 
     if neon_config is None:
@@ -150,5 +155,8 @@ async def get_hub_config() -> HubConfigResponse:
     return HubConfigResponse(
         tts=tts,
         stt=stt,
-        llm=LLMConfig(name="Neon Classic"),
+        llm=LLMPersona(
+            name="Neon Classic",
+            description="OVOS parser-based assistant (no LLM)",
+        ),
     )

--- a/neon_hana/app/routers/hub.py
+++ b/neon_hana/app/routers/hub.py
@@ -1,0 +1,82 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2026 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from fastapi import APIRouter, Depends
+from ovos_config.config import update_mycroft_config
+from ovos_utils.log import LOG
+
+from neon_hana.app.dependencies import config, jwt_bearer
+from neon_hana.hub_id import generate_hub_id
+from neon_hana.schema.hub_requests import HubIdentityResponse, UpdateHubIdentityRequest
+from neon_hana.version import __version__
+
+hub_route = APIRouter(prefix="/hub", tags=["hub"])
+
+# Generate hub_id eagerly at import time to avoid a race condition
+# where two concurrent first-boot requests each generate a different ID.
+_hub_id = config.get("hub_id")
+if not _hub_id:
+    _hub_id = generate_hub_id()
+    LOG.info("Generated new hub_id: %s", _hub_id)
+    update_mycroft_config({"hana": {"hub_id": _hub_id}})
+    config["hub_id"] = _hub_id
+
+
+@hub_route.get("/identity")
+async def get_hub_identity() -> HubIdentityResponse:
+    """
+    Get the identity of this Hub.
+
+    Returns a stable hub ID, user-configurable display name, and
+    software version. This endpoint is public (no authentication
+    required) so that Nodes can identify a Hub during discovery.
+    """
+    display_name = config.get("hub_display_name") or "Neon Hub"
+    return HubIdentityResponse(
+        hub_id=_hub_id,
+        display_name=display_name,
+        version=__version__,
+    )
+
+
+@hub_route.post("/identity", dependencies=[Depends(jwt_bearer)])
+async def update_hub_identity(
+    request: UpdateHubIdentityRequest,
+) -> HubIdentityResponse:
+    """
+    Update the display name of this Hub.
+
+    Requires authentication. The new display name is persisted to
+    the configuration file and survives container restarts.
+    """
+    update_mycroft_config({"hana": {"hub_display_name": request.display_name}})
+    config["hub_display_name"] = request.display_name
+    LOG.info("Hub display_name updated to: %s", request.display_name)
+    return HubIdentityResponse(
+        hub_id=_hub_id,
+        display_name=request.display_name,
+        version=__version__,
+    )

--- a/neon_hana/app/routers/hub.py
+++ b/neon_hana/app/routers/hub.py
@@ -28,8 +28,10 @@ import os
 from typing import Optional
 
 import yaml
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from neon_data_models.enum import AccessRoles
 from neon_data_models.models.api.llm import LLMPersona
+from neon_data_models.models.user.database import PermissionsConfig
 from ovos_config.config import update_mycroft_config
 from ovos_utils.log import LOG
 
@@ -55,7 +57,10 @@ _hub_id = config.get("hub_id")
 if not _hub_id:
     _hub_id = generate_hub_id()
     LOG.info("Generated new hub_id: %s", _hub_id)
-    update_mycroft_config({"hana": {"hub_id": _hub_id}})
+    try:
+        update_mycroft_config({"hana": {"hub_id": _hub_id}})
+    except Exception as e:
+        LOG.error("Failed to persist hub_id to config: %s", e)
     config["hub_id"] = _hub_id
 
 
@@ -76,23 +81,37 @@ async def get_hub_identity() -> HubIdentityResponse:
     )
 
 
-@hub_route.post("/identity", dependencies=[Depends(jwt_bearer)])
+@hub_route.post("/identity")
 async def update_hub_identity(
     request: UpdateHubIdentityRequest,
+    token: str = Depends(jwt_bearer),
 ) -> HubIdentityResponse:
     """
     Update the display name of this Hub.
 
-    Requires authentication. The new display name is persisted to
-    the configuration file and survives container restarts.
+    Requires hub: ADMIN permission. The new display name is persisted
+    to the configuration file and survives container restarts.
     """
-    update_mycroft_config({"hana": {"hub_display_name": request.display_name}})
+    permissions = PermissionsConfig.from_roles(
+        jwt_bearer.client_manager.get_token_data(token).roles)
+    if permissions.hub < AccessRoles.ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Insufficient Hub management permission ({permissions.hub})",
+        )
+    warning = None
+    try:
+        update_mycroft_config({"hana": {"hub_display_name": request.display_name}})
+    except Exception as e:
+        LOG.error("Failed to persist hub_display_name to config: %s", e)
+        warning = "Display name updated in memory but could not be persisted to disk. It will revert on restart."
     config["hub_display_name"] = request.display_name
     LOG.info("Hub display_name updated to: %s", request.display_name)
     return HubIdentityResponse(
         hub_id=_hub_id,
         display_name=request.display_name,
         version=__version__,
+        warning=warning,
     )
 
 

--- a/neon_hana/auth/client_manager.py
+++ b/neon_hana/auth/client_manager.py
@@ -240,6 +240,7 @@ class ClientManager:
     def check_auth_request(self, client_id: str, username: str,
                            password: Optional[str] = None,
                            token_name: Optional[str] = None,
+                           node_auth: bool = False,
                            origin_ip: str = "127.0.0.1") -> AuthenticationResponse:
         """
         Authenticate and Authorize a new client connection with the specified
@@ -278,10 +279,16 @@ class ClientManager:
         else:
             user = self._run_async(self._mq_connector.read_user(username, password))
 
+        permissions = user.permissions
+        if node_auth:
+            permissions = PermissionsConfig(
+                **{field: AccessRoles.NODE
+                   for field in PermissionsConfig.model_fields})
+
         create_time = round(time())
         encode_data = {"client_id": client_id,
                        "user_id": user.user_id,
-                       "permissions": user.permissions,
+                       "permissions": permissions,
                        "token_name": token_name,
                        "last_refresh_timestamp": create_time}
         access, refresh, config = self._create_tokens(**encode_data)

--- a/neon_hana/auth/client_manager.py
+++ b/neon_hana/auth/client_manager.py
@@ -249,6 +249,9 @@ class ClientManager:
         @param username: Supplied username to authenticate
         @param password: Supplied password to authenticate
         @param token_name: Token name to add to user database
+        @param node_auth: If True, override permissions to AccessRoles.NODE for
+            all fields so issued tokens are scoped as a Node service account
+            (no user-level permissions unless explicitly granted)
         @param origin_ip: Origin IP address of request
         @return: response tokens, permissions, and other metadata
         """

--- a/neon_hana/hub_id.py
+++ b/neon_hana/hub_id.py
@@ -1,0 +1,84 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2026 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Generate memorable, Docker-style hub identifiers.
+
+Produces kebab-case names like "bright-silver-falcon" or
+"calm-amber-river-stone" that are easier to remember than UUIDs
+when a user needs to identify which Hub they're connected to.
+"""
+
+import secrets
+
+# 82 adjectives — evocative, whimsical, deliberately nonsequitur
+# paired with tech nouns for maximum personality.
+# Pruned: adjectives that are too specifically plant/terrain
+# (mossy, pine, cedar, fern, oaken, marsh, timber, willow, rowan, etc.)
+# The test: does "[adjective]-synapse" sound cool or silly?
+_ADJECTIVES = [
+    "ancient", "amber", "arctic", "azure", "bold", "brave", "bright",
+    "bronze", "calm", "clear", "clever", "cobalt", "coral", "cosmic",
+    "crisp", "crystal", "daring", "dawn", "deep", "eager", "ember",
+    "fair", "fierce", "frost", "gentle", "gilded", "glad", "golden",
+    "grand", "hidden", "hollow", "iron", "ivory", "jade", "keen",
+    "kind", "lapis", "light", "lilac", "lively", "lunar", "marble",
+    "merry", "noble", "north", "onyx", "opal", "pale", "pearl",
+    "plain", "plum", "polar", "proud", "quiet", "rapid", "ruby",
+    "scarlet", "serene", "shadow", "sharp", "silent", "silver", "slate",
+    "solar", "south", "steady", "steel", "still", "storm", "sunny",
+    "swift", "tawny", "teal", "tender", "topaz", "true", "velvet",
+    "vivid", "warm", "west", "wild", "wise",
+]
+
+# 73 nouns — AI, computing, science, engineering
+_NOUNS = [
+    "agent", "array", "aurora", "batch", "beacon", "cache", "charge",
+    "cipher", "circuit", "codec", "coil", "core", "cortex", "diode",
+    "echo", "epoch", "field", "flux", "forge", "gate", "glyph",
+    "graph", "grid", "helix", "index", "kernel", "laser", "lattice",
+    "lens", "link", "loom", "matrix", "mesh", "model", "modem",
+    "neuron", "nexus", "node", "optic", "orbit", "parse", "patch",
+    "phase", "photon", "pixel", "plasma", "probe", "prism", "pulse",
+    "qubit", "radar", "relay", "rotor", "scope", "servo", "shard",
+    "signal", "socket", "sonar", "spark", "stack", "switch", "sync",
+    "synapse", "tensor", "token", "trace", "valve", "vector", "vertex",
+    "voxel", "watt", "wave",
+]
+
+
+_rng = secrets.SystemRandom()
+
+
+def generate_hub_id() -> str:
+    """Generate a three-word kebab-case identifier.
+
+    Format: adjective-adjective-noun (adjectives are always distinct)
+    Combinatorial space: 82 * 81 * 73 ≈ 485K unique IDs.
+    Collision probability is negligible for home networks.
+    """
+    adj1, adj2 = _rng.sample(_ADJECTIVES, 2)
+    noun = _rng.choice(_NOUNS)
+    return f"{adj1}-{adj2}-{noun}"

--- a/neon_hana/schema/auth_requests.py
+++ b/neon_hana/schema/auth_requests.py
@@ -38,6 +38,11 @@ class AuthenticationRequest(BaseModel):
     password: Optional[str] = None
     token_name: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
     client_id: str = Field(default_factory=lambda: str(uuid4()))
+    node_auth: bool = Field(
+        default=False,
+        description="If true, issued tokens are scoped to AccessRoles.NODE "
+                    "regardless of the user's actual permissions. Used by "
+                    "Node devices to obtain limited-privilege tokens.")
 
     model_config = {
         "json_schema_extra": {
@@ -45,6 +50,11 @@ class AuthenticationRequest(BaseModel):
                 "username": "guest",
                 "password": "password",
                 "token_name": "My Client"
+            }, {
+                "username": "alice",
+                "password": "password",
+                "token_name": "Alice's Phone",
+                "node_auth": True,
             }]}}
 
 

--- a/neon_hana/schema/hub_requests.py
+++ b/neon_hana/schema/hub_requests.py
@@ -26,6 +26,7 @@
 
 from typing import Optional
 
+from neon_data_models.models.api.llm import LLMPersona
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -41,12 +42,6 @@ class STTConfig(BaseModel):
     module: str = Field(description="Active STT plugin module name")
 
 
-class LLMConfig(BaseModel):
-    """LLM configuration."""
-
-    name: str = Field(description="Active LLM engine name")
-
-
 class HubConfigResponse(BaseModel):
     """Response model for GET /hub/config."""
 
@@ -58,7 +53,7 @@ class HubConfigResponse(BaseModel):
         default=None,
         description="Active STT configuration, or null if unavailable",
     )
-    llm: LLMConfig = Field(description="Active LLM configuration")
+    llm: LLMPersona = Field(description="Active LLM persona")
 
     model_config = {
         "json_schema_extra": {
@@ -66,7 +61,11 @@ class HubConfigResponse(BaseModel):
                 {
                     "tts": {"module": "neon-tts-plugin-coqui"},
                     "stt": {"module": "neon-stt-plugin-nemo"},
-                    "llm": {"name": "Neon Classic"},
+                    "llm": {
+                        "persona_name": "Neon Classic",
+                        "description": "OVOS parser-based assistant (no LLM)",
+                        "enabled": True,
+                    },
                 }
             ]
         }

--- a/neon_hana/schema/hub_requests.py
+++ b/neon_hana/schema/hub_requests.py
@@ -78,6 +78,7 @@ class HubIdentityResponse(BaseModel):
     hub_id: str = Field(description="Stable, human-readable hub identifier (e.g. 'bright-silver-falcon')")
     display_name: str = Field(description="User-configurable display name for this hub")
     version: str = Field(description="HANA software version")
+    warning: Optional[str] = Field(default=None, description="Non-fatal warning, e.g. config persistence failure")
 
     model_config = {
         "json_schema_extra": {
@@ -86,6 +87,7 @@ class HubIdentityResponse(BaseModel):
                     "hub_id": "bright-silver-falcon",
                     "display_name": "Neon Hub (Office)",
                     "version": "0.1.1a21",
+                    "warning": None,
                 }
             ]
         }

--- a/neon_hana/schema/hub_requests.py
+++ b/neon_hana/schema/hub_requests.py
@@ -1,0 +1,71 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2026 Neongecko.com Inc.
+# BSD-3
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class HubIdentityResponse(BaseModel):
+    """Response model for GET /hub/identity."""
+
+    hub_id: str = Field(description="Stable, human-readable hub identifier (e.g. 'bright-silver-falcon')")
+    display_name: str = Field(description="User-configurable display name for this hub")
+    version: str = Field(description="HANA software version")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "hub_id": "bright-silver-falcon",
+                    "display_name": "Neon Hub (Office)",
+                    "version": "0.1.1a21",
+                }
+            ]
+        }
+    }
+
+
+class UpdateHubIdentityRequest(BaseModel):
+    """Request model for POST /hub/identity."""
+
+    display_name: str = Field(min_length=1, max_length=128, description="New display name for this hub")
+
+    @field_validator("display_name")
+    @classmethod
+    def strip_and_validate(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("display_name must not be blank")
+        return v
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "display_name": "Kitchen Hub",
+                }
+            ]
+        }
+    }

--- a/neon_hana/schema/hub_requests.py
+++ b/neon_hana/schema/hub_requests.py
@@ -24,7 +24,53 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from typing import Optional
+
 from pydantic import BaseModel, Field, field_validator
+
+
+class TTSConfig(BaseModel):
+    """TTS plugin configuration."""
+
+    module: str = Field(description="Active TTS plugin module name")
+
+
+class STTConfig(BaseModel):
+    """STT plugin configuration."""
+
+    module: str = Field(description="Active STT plugin module name")
+
+
+class LLMConfig(BaseModel):
+    """LLM configuration."""
+
+    name: str = Field(description="Active LLM engine name")
+
+
+class HubConfigResponse(BaseModel):
+    """Response model for GET /hub/config."""
+
+    tts: Optional[TTSConfig] = Field(
+        default=None,
+        description="Active TTS configuration, or null if unavailable",
+    )
+    stt: Optional[STTConfig] = Field(
+        default=None,
+        description="Active STT configuration, or null if unavailable",
+    )
+    llm: LLMConfig = Field(description="Active LLM configuration")
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "tts": {"module": "neon-tts-plugin-coqui"},
+                    "stt": {"module": "neon-stt-plugin-nemo"},
+                    "llm": {"name": "Neon Classic"},
+                }
+            ]
+        }
+    }
 
 
 class HubIdentityResponse(BaseModel):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,6 +5,7 @@ pydantic~=2.5
 pyjwt~=2.8
 token-throttler~=1.4
 neon-mq-connector~=0.7,>=0.8.1a3
+neon-utils>=1.14.1a1
 ovos-config~=0.0,>=0.0.12
 ovos-utils~=0.0,>=0.0.38
 neon-data-models~=0.0,>=0.0.2a11

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -105,6 +105,31 @@ class TestHanaApp(TestCase):
                          422)
 
     @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_auth_login_node_auth(self, send_request):
+        admin_user = User(
+            username="admin", password_hash="password",
+            permissions=PermissionsConfig(hub=30, core=20, diana=20,
+                                         node=20, llm=20))
+        send_request.return_value = {"user": admin_user.model_dump(),
+                                     "success": True}
+        response = self.test_app.post("/auth/login",
+                                      json={"username": "admin",
+                                            "password": "password",
+                                            "node_auth": True})
+        self.assertEqual(response.status_code, 200, response.text)
+        token = response.json()["access_token"]
+
+        # Verify token has NODE permissions, not the user's ADMIN
+        perms_response = self.test_app.post(
+            "/auth/permissions",
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(perms_response.status_code, 200, perms_response.text)
+        perms = perms_response.json()
+        self.assertEqual(perms["hub"], -1)
+        self.assertEqual(perms["core"], -1)
+        self.assertEqual(perms["node"], -1)
+
+    @patch("neon_hana.mq_service_api.send_mq_request")
     def test_auth_refresh(self, send_request):
         valid_user = User(username="guest", password_hash="password")
         send_request.return_value = {"user": valid_user.model_dump(),

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -586,6 +586,9 @@ class TestHanaApp(TestCase):
     @patch("neon_hana.app.routers.hub.update_mycroft_config")
     @patch("neon_hana.mq_service_api.send_mq_request")
     def test_hub_identity_update(self, send_request, mock_config_write):
+        from neon_hana.app.dependencies import config
+        self.addCleanup(config.pop, "hub_display_name", None)
+
         token = self._get_tokens()["access_token"]
         original = self.test_app.get("/hub/identity").json()
 
@@ -624,10 +627,6 @@ class TestHanaApp(TestCase):
             json={"display_name": "x" * 128},
             headers={"Authorization": f"Bearer {token}"})
         self.assertEqual(response.status_code, 200, response.text)
-
-        # Restore default to avoid test ordering issues
-        from neon_hana.app.dependencies import config
-        config.pop("hub_display_name", None)
 
     @patch("neon_hana.mq_service_api.send_mq_request")
     def test_hub_identity_update_auth_required(self, send_request):
@@ -672,5 +671,125 @@ class TestHanaApp(TestCase):
 
         # Config was never written for invalid requests
         mock_config_write.assert_not_called()
+
+    @patch("neon_hana.app.routers.hub._read_neon_yaml")
+    def test_hub_config_with_explicit_config(self, mock_read):
+        mock_read.return_value = {
+            "tts": {"module": "ovos-tts-plugin-mimic"},
+            "stt": {"module": "ovos-stt-plugin-vosk"},
+        }
+        response = self.test_app.get("/hub/config")
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data["tts"]["module"], "ovos-tts-plugin-mimic")
+        self.assertEqual(data["stt"]["module"], "ovos-stt-plugin-vosk")
+        self.assertEqual(data["llm"]["name"], "Neon Classic")
+
+    @patch("neon_hana.app.routers.hub._read_neon_yaml")
+    def test_hub_config_defaults(self, mock_read):
+        # neon.yaml exists but has no tts/stt keys — returns defaults
+        mock_read.return_value = {"lang": "en-us"}
+        response = self.test_app.get("/hub/config")
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data["tts"]["module"], "neon-tts-plugin-coqui")
+        self.assertEqual(data["stt"]["module"], "neon-stt-plugin-nemo")
+
+    @patch("neon_hana.app.routers.hub._read_neon_yaml")
+    def test_hub_config_no_neon_yaml(self, mock_read):
+        # neon.yaml doesn't exist (non-Hub deployment)
+        mock_read.return_value = None
+        response = self.test_app.get("/hub/config")
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertIsNone(data["tts"])
+        self.assertIsNone(data["stt"])
+        self.assertEqual(data["llm"]["name"], "Neon Classic")
+
+    @patch("neon_hana.app.routers.hub._read_neon_yaml")
+    def test_hub_config_key_without_module(self, mock_read):
+        # tts/stt keys exist but module sub-key is absent — returns defaults
+        mock_read.return_value = {"tts": {"lang": "en-us"}, "stt": {"lang": "en-us"}}
+        response = self.test_app.get("/hub/config")
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data["tts"]["module"], "neon-tts-plugin-coqui")
+        self.assertEqual(data["stt"]["module"], "neon-stt-plugin-nemo")
+
+    @patch("neon_hana.app.routers.hub._read_neon_yaml")
+    def test_hub_config_none_values(self, mock_read):
+        # tts/stt keys exist but are explicitly None — returns defaults
+        mock_read.return_value = {"tts": None, "stt": None}
+        response = self.test_app.get("/hub/config")
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data["tts"]["module"], "neon-tts-plugin-coqui")
+        self.assertEqual(data["stt"]["module"], "neon-stt-plugin-nemo")
+
+    def test_hub_config_no_auth_required(self):
+        # Public discovery endpoint — must not require authentication
+        response = self.test_app.get("/hub/config")
+        self.assertNotIn(response.status_code, [401, 403],
+                         "GET /hub/config should not require authentication")
+
+    def test_read_neon_yaml_permission_error(self):
+        import os
+        from neon_hana.app.routers.hub import _read_neon_yaml
+        with patch.dict(os.environ, {"XDG_CONFIG_HOME": "/tmp/_neon_test_perm"}):
+            with patch("builtins.open",
+                       side_effect=PermissionError("Permission denied")):
+                result = _read_neon_yaml()
+        self.assertIsNone(result)
+
+    def test_read_neon_yaml_is_directory(self):
+        import tempfile, os
+        from neon_hana.app.routers.hub import _read_neon_yaml
+        with tempfile.TemporaryDirectory() as tmpdir:
+            neon_dir = os.path.join(tmpdir, "neon")
+            os.makedirs(neon_dir)
+            # Create neon.yaml as a directory instead of a file
+            os.makedirs(os.path.join(neon_dir, "neon.yaml"))
+            with patch.dict(os.environ, {"XDG_CONFIG_HOME": tmpdir}):
+                result = _read_neon_yaml()
+            self.assertIsNone(result)
+
+    def test_read_neon_yaml_malformed_yaml(self):
+        import tempfile, os
+        from neon_hana.app.routers.hub import _read_neon_yaml
+        with tempfile.TemporaryDirectory() as tmpdir:
+            neon_dir = os.path.join(tmpdir, "neon")
+            os.makedirs(neon_dir)
+            yaml_path = os.path.join(neon_dir, "neon.yaml")
+            with open(yaml_path, "w") as f:
+                f.write("tts: [invalid\n  bad: yaml:")
+            with patch.dict(os.environ, {"XDG_CONFIG_HOME": tmpdir}):
+                result = _read_neon_yaml()
+            self.assertIsNone(result)
+
+    def test_read_neon_yaml_non_dict(self):
+        import tempfile, os
+        from neon_hana.app.routers.hub import _read_neon_yaml
+        with tempfile.TemporaryDirectory() as tmpdir:
+            neon_dir = os.path.join(tmpdir, "neon")
+            os.makedirs(neon_dir)
+            yaml_path = os.path.join(neon_dir, "neon.yaml")
+            with open(yaml_path, "w") as f:
+                f.write("- item1\n- item2\n")
+            with patch.dict(os.environ, {"XDG_CONFIG_HOME": tmpdir}):
+                result = _read_neon_yaml()
+            self.assertIsNone(result)
+
+    def test_read_neon_yaml_empty_file(self):
+        import tempfile, os
+        from neon_hana.app.routers.hub import _read_neon_yaml
+        with tempfile.TemporaryDirectory() as tmpdir:
+            neon_dir = os.path.join(tmpdir, "neon")
+            os.makedirs(neon_dir)
+            yaml_path = os.path.join(neon_dir, "neon.yaml")
+            with open(yaml_path, "w") as f:
+                f.write("")
+            with patch.dict(os.environ, {"XDG_CONFIG_HOME": tmpdir}):
+                result = _read_neon_yaml()
+            self.assertEqual(result, {})
 
 # TODO: Define node endpoint tests

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -683,7 +683,7 @@ class TestHanaApp(TestCase):
         data = response.json()
         self.assertEqual(data["tts"]["module"], "ovos-tts-plugin-mimic")
         self.assertEqual(data["stt"]["module"], "ovos-stt-plugin-vosk")
-        self.assertEqual(data["llm"]["name"], "Neon Classic")
+        self.assertEqual(data["llm"]["persona_name"], "Neon Classic")
 
     @patch("neon_hana.app.routers.hub._read_neon_yaml")
     def test_hub_config_defaults(self, mock_read):
@@ -704,7 +704,7 @@ class TestHanaApp(TestCase):
         data = response.json()
         self.assertIsNone(data["tts"])
         self.assertIsNone(data["stt"])
-        self.assertEqual(data["llm"]["name"], "Neon Classic")
+        self.assertEqual(data["llm"]["persona_name"], "Neon Classic")
 
     @patch("neon_hana.app.routers.hub._read_neon_yaml")
     def test_hub_config_key_without_module(self, mock_read):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -568,4 +568,109 @@ class TestHanaApp(TestCase):
         for key, val in test_headers.items():
             self.assertEqual(response.json()[key.lower()], val, response.json())
 
+    def test_hub_identity_get(self):
+        # Public endpoint, no auth required
+        response = self.test_app.get("/hub/identity")
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertTrue(data["hub_id"], "hub_id should be non-empty")
+
+    def test_hub_identity_stable(self):
+        # hub_id must not change across calls
+        id1 = self.test_app.get("/hub/identity").json()["hub_id"]
+        id2 = self.test_app.get("/hub/identity").json()["hub_id"]
+        id3 = self.test_app.get("/hub/identity").json()["hub_id"]
+        self.assertEqual(id1, id2)
+        self.assertEqual(id2, id3)
+
+    @patch("neon_hana.app.routers.hub.update_mycroft_config")
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_hub_identity_update(self, send_request, mock_config_write):
+        token = self._get_tokens()["access_token"]
+        original = self.test_app.get("/hub/identity").json()
+
+        # Valid update
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "Kitchen Hub"},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 200, response.text)
+        data = response.json()
+        self.assertEqual(data["display_name"], "Kitchen Hub")
+        self.assertEqual(data["hub_id"], original["hub_id"])
+        mock_config_write.assert_called()
+
+        # Verify persistence in memory
+        data = self.test_app.get("/hub/identity").json()
+        self.assertEqual(data["display_name"], "Kitchen Hub")
+
+        # Whitespace is stripped from valid input
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "  Living Room Hub  "},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.json()["display_name"], "Living Room Hub")
+
+        # Boundary: 1-char name accepted
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "X"},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 200, response.text)
+
+        # Boundary: 128-char name accepted
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "x" * 128},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 200, response.text)
+
+        # Restore default to avoid test ordering issues
+        from neon_hana.app.dependencies import config
+        config.pop("hub_display_name", None)
+
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_hub_identity_update_auth_required(self, send_request):
+        # Missing auth
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "No Auth Hub"})
+        self.assertIn(response.status_code, [401, 403], response.text)
+
+    @patch("neon_hana.app.routers.hub.update_mycroft_config")
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_hub_identity_update_validation(self, send_request,
+                                            mock_config_write):
+        token = self._get_tokens()["access_token"]
+
+        # Empty display_name
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": ""},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Whitespace-only display_name
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "   "},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Too long display_name
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "x" * 129},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Missing body
+        response = self.test_app.post(
+            "/hub/identity",
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 422, response.text)
+
+        # Config was never written for invalid requests
+        mock_config_write.assert_not_called()
+
 # TODO: Define node endpoint tests

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from neon_data_models.models.user import User
+from neon_data_models.models.user.database import PermissionsConfig
 
 _TEST_CONFIG = {
     "mq_default_timeout": 10,
@@ -50,6 +51,21 @@ class TestHanaApp(TestCase):
             self.tokens = response.json()
             self.assertIn("access_token", self.tokens, self.tokens)
         return self.tokens
+
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def _get_admin_tokens(self, send_request):
+        admin_user = User(
+            username="admin", password_hash="password",
+            permissions=PermissionsConfig(hub=30, core=20, diana=20,
+                                         node=20, llm=20))
+        send_request.return_value = {"user": admin_user.model_dump(),
+                                     "success": True}
+        response = self.test_app.post("/auth/login",
+                                      json={"username": "admin",
+                                            "password": "password"})
+        tokens = response.json()
+        self.assertIn("access_token", tokens, tokens)
+        return tokens
 
     def test_app_init(self):
         self.assertEqual(self.test_app.app.title, _TEST_CONFIG["fastapi_title"])
@@ -589,7 +605,7 @@ class TestHanaApp(TestCase):
         from neon_hana.app.dependencies import config
         self.addCleanup(config.pop, "hub_display_name", None)
 
-        token = self._get_tokens()["access_token"]
+        token = self._get_admin_tokens()["access_token"]
         original = self.test_app.get("/hub/identity").json()
 
         # Valid update
@@ -636,11 +652,21 @@ class TestHanaApp(TestCase):
             json={"display_name": "No Auth Hub"})
         self.assertIn(response.status_code, [401, 403], response.text)
 
+    @patch("neon_hana.mq_service_api.send_mq_request")
+    def test_hub_identity_update_insufficient_permissions(self, send_request):
+        # Guest user (hub: 0) should be rejected
+        token = self._get_tokens()["access_token"]
+        response = self.test_app.post(
+            "/hub/identity",
+            json={"display_name": "Unauthorized Hub"},
+            headers={"Authorization": f"Bearer {token}"})
+        self.assertEqual(response.status_code, 403, response.text)
+
     @patch("neon_hana.app.routers.hub.update_mycroft_config")
     @patch("neon_hana.mq_service_api.send_mq_request")
     def test_hub_identity_update_validation(self, send_request,
                                             mock_config_write):
-        token = self._get_tokens()["access_token"]
+        token = self._get_admin_tokens()["access_token"]
 
         # Empty display_name
         response = self.test_app.post(

--- a/tests/test_hub_id.py
+++ b/tests/test_hub_id.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from neon_hana.hub_id import generate_hub_id, _ADJECTIVES, _NOUNS
+
+
+class TestHubIdGenerator(TestCase):
+    def test_words_from_lists(self):
+        hub_id = generate_hub_id()
+        adj1, adj2, noun = hub_id.split("-")
+        self.assertIn(adj1, _ADJECTIVES, f"{adj1} not in adjectives")
+        self.assertIn(adj2, _ADJECTIVES, f"{adj2} not in adjectives")
+        self.assertIn(noun, _NOUNS, f"{noun} not in nouns")
+
+    def test_adjectives_always_distinct(self):
+        for _ in range(5):
+            adj1, adj2, _ = generate_hub_id().split("-")
+            self.assertNotEqual(adj1, adj2,
+                                "Both adjective slots drew the same word")
+
+    def test_no_duplicates_in_word_lists(self):
+        self.assertEqual(len(_ADJECTIVES), len(set(_ADJECTIVES)),
+                         "Duplicate adjectives found")
+        self.assertEqual(len(_NOUNS), len(set(_NOUNS)),
+                         "Duplicate nouns found")


### PR DESCRIPTION
## Summary

- **Hub Identity (CO1 2.3):** `GET /hub/identity` returns a stable, memorable hub ID (e.g. `bold-crystal-synapse`), user-configurable display name, and software version. `POST /hub/identity` (auth required) updates the display name. Hub ID is generated once at first boot and persisted to config.
- **Hub Config (CO1 2.4):** `GET /hub/config` returns the active TTS, STT, and LLM engine names. TTS/STT are read from `neon.yaml` with known defaults (`neon-tts-plugin-coqui`, `neon-stt-plugin-nemo`) as fallback. LLM is hardcoded to "Neon Classic". Gracefully handles missing, malformed, or unreadable `neon.yaml` for non-Hub deployments.
- Both discovery endpoints are public (no auth) so Nodes can identify and inspect a Hub during network discovery.

## Files changed

- `neon_hana/hub_id.py` — Docker-style 3-word kebab-case ID generator (new)
- `neon_hana/schema/hub_requests.py` — Pydantic v2 request/response models (new)
- `neon_hana/app/routers/hub.py` — Hub router with identity + config endpoints (new)
- `neon_hana/app/__init__.py` — Register hub router
- `tests/test_hub_id.py` — Generator unit tests (new)
- `tests/test_app.py` — 16 new endpoint and edge case tests

## Test plan

- [ ] `GET /hub/identity` returns 200 with non-empty `hub_id`, `display_name`, `version`
- [ ] `hub_id` is stable across requests and container restarts
- [ ] `POST /hub/identity` with valid auth updates display name (whitespace stripped)
- [ ] `POST /hub/identity` without auth returns 401/403
- [ ] `GET /hub/config` returns TTS/STT module names from neon.yaml
- [ ] `GET /hub/config` returns defaults when neon.yaml has no TTS/STT keys
- [ ] `GET /hub/config` returns null TTS/STT when neon.yaml is absent
- [ ] All 45 tests pass in Docker (`ghcr.io/neongeckocom/neon-hana:dev`)