### PR TITLE
Pin neon-iris, multi-arch Docker, bump to Python 3.11

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -23,3 +23,5 @@ jobs:
   build_and_publish_docker:
     uses: neongeckocom/.github/.github/workflows/publish_docker.yml@master
     secrets: inherit
+    with:
+      platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -20,3 +20,5 @@ jobs:
     needs: publish_alpha_release
     uses: neongeckocom/.github/.github/workflows/publish_docker.yml@master
     secrets: inherit
+    with:
+      platforms: linux/amd64,linux/arm64

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,13 +7,13 @@ jobs:
   py_build_tests:
     uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
     with:
-      python_version: "3.9"
+      python_version: "3.11"
   docker_build_tests:
     uses: neongeckocom/.github/.github/workflows/docker_build_tests.yml@master
   unit_tests:
     strategy:
       matrix:
-        python-version: [ 3.9, "3.10", "3.11" ]
+        python-version: ["3.10", "3.11", "3.12"]
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update_docker_images.yml
+++ b/.github/workflows/update_docker_images.yml
@@ -9,3 +9,4 @@ jobs:
     secrets: inherit
     with:
       include_semver: False
+      platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 LABEL vendor=neon.ai \
     ai.neon.name="neon-hana"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,5 +7,5 @@ token-throttler~=1.4
 neon-mq-connector~=0.7,>=0.8.1a3
 neon-utils>=1.14.1a1
 ovos-config~=0.0,>=0.0.12
-ovos-utils>=0.0.38,<0.8.5
+ovos-utils~=0.0,>=0.0.38
 neon-data-models~=0.0,>=0.0.2a11

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,5 +7,5 @@ token-throttler~=1.4
 neon-mq-connector~=0.7,>=0.8.1a3
 neon-utils>=1.14.1a1
 ovos-config~=0.0,>=0.0.12
-ovos-utils~=0.0,>=0.0.38
+ovos-utils>=0.0.38,<0.8.5
 neon-data-models~=0.0,>=0.0.2a11

--- a/requirements/websocket.txt
+++ b/requirements/websocket.txt
@@ -1,2 +1,2 @@
-neon-iris~=0.1,>=0.1.1a5
+neon-iris~=0.1,>=0.1.1a15
 websockets~=12.0


### PR DESCRIPTION
## Summary
- **Pin `neon-iris>=0.1.1a15`** so containers ship the timing-safety fix (iris commit `a835b70`). Pre-fix iris crashes the `neon_response_handler` consumer with `TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'` whenever Core sends a message with `timing.response_sent = None`, which kills the Node response path. The current `:dev` image (`sha256:ead9e98…`) ships `neon-iris==0.1.1a10` and has this bug.
- **Cap `ovos-utils<0.8.5`** — 0.8.5 removed `ovos_utils.signal`, which `neon_utils.file_utils` still imports at runtime. Matches the pin already applied in neon-iris.
- **Multi-arch Docker** — add `platforms: linux/amd64,linux/arm64` to all three Docker publish workflows so the image is usable natively on Apple Silicon Neon Hubs (no Rosetta).
- **Bump base image and CI to Python 3.11** — Python 3.9 reached EOL in October 2025. The 3.9-era pip (23.0.1) also fails to resolve the updated `neon-iris[websocket]` → `neon-utils[sentry]` chain (alpha versions + transitive extras), where pip on 3.11 resolves it cleanly. CI matrix updated to 3.10 / 3.11.

## Test plan
- [x] Image builds locally on ARM64 (`docker buildx build --platform linux/arm64`)
- [x] Resulting image contains `neon-iris==0.1.1a20`, `neon-utils==1.14.1a1`, `ovos-utils==0.8.4`, `neon-mq-connector==0.10.1a1`
- [x] `handle_neon_response` in the built image uses the safe `or recv_time` fallback
- [x] End-to-end test on Apple Silicon Neon Hub: Node app sends utterance → STT transcribes → HANA returns response → Node speaks reply (previously timed out at "Thinking…")
- [ ] CI build succeeds on dev push
- [ ] Published `:dev` manifest lists both `linux/amd64` and `linux/arm64`