### PR TITLE
Remove `palm` endpoint that is no longer supported by Google

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -9,4 +9,4 @@ jobs:
   license_tests:
     uses: neongeckocom/.github/.github/workflows/license_tests.yml@master
     with:
-      packages-exclude: '^(neon-hana|dnspython|typing_extensions|click|typing-inspection|urllib).*'
+      packages-exclude: '^(neon-hana|dnspython|typing_extensions|click|typing-inspection|urllib|orjson).*'

--- a/neon_hana/app/routers/llm.py
+++ b/neon_hana/app/routers/llm.py
@@ -52,7 +52,3 @@ async def llm_ask_gemini(query: LLMRequest) -> LLMResponse:
 async def llm_ask_claude(query: LLMRequest) -> LLMResponse:
     return await mq_connector.query_llm("claude", **dict(query))
 
-
-@llm_route.post("/palm")
-async def llm_ask_palm(query: LLMRequest) -> LLMResponse:
-    return await mq_connector.query_llm("palm2", **dict(query))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -571,13 +571,6 @@ class TestHanaApp(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), valid_response)
 
-        # Palm
-        response = self.test_app.post("/llm/palm",
-                                      json=valid_request,
-                                      headers={"Authorization": f"Bearer {token}"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), valid_response)
-
         # Invalid requests
         response = self.test_app.post("/llm/chatgpt",
                                       json=valid_request)


### PR DESCRIPTION
# Description
Remove `palm` LLM endpoint

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- Official deprecation notice appears to be gone, but other issues reference a 2024 deprecation date https://github.com/spring-projects/spring-ai/issues/924