### PR TITLE
Add Node native action support (node.hello, node.invoke_native)

### DIFF
--- a/neon_hana/app/routers/node_server.py
+++ b/neon_hana/app/routers/node_server.py
@@ -42,6 +42,9 @@ from neon_data_models.models.api.node_v1 import (NodeAudioInput, NodeGetStt,
                                                  NodeAudioInputResponse,
                                                  NodeGetSttResponse,
                                                  NodeGetTtsResponse,
+                                                 NodeHello,
+                                                 NodeInvokeNative,
+                                                 NodeInvokeNativeResponse,
                                                  CoreWWDetected,
                                                  CoreIntentFailure,
                                                  CoreErrorResponse,
@@ -110,9 +113,11 @@ async def node_v1_stream_endpoint(websocket: WebSocket, token: str):
 
 @node_route.get("/v1/doc")
 async def node_v1_doc(_: Optional[Union[NodeAudioInput, NodeGetStt,
-                                        NodeGetTts]]) -> \
+                                        NodeGetTts, NodeHello,
+                                        NodeInvokeNativeResponse]]) -> \
         Optional[Union[NodeKlatResponse, NodeAudioInputResponse,
                        NodeGetSttResponse, NodeGetTtsResponse,
+                       NodeInvokeNative,
                        CoreWWDetected, CoreIntentFailure, CoreErrorResponse,
                        CoreClearData, CoreAlertExpired]]:
     """

--- a/neon_hana/mq_websocket_api.py
+++ b/neon_hana/mq_websocket_api.py
@@ -30,8 +30,11 @@ from queue import Queue
 from time import time, sleep
 from typing import Optional
 from fastapi import WebSocket
+from neon_data_models.models.api.node_v1 import NodeHello
 from neon_iris.client import NeonAIClient
+from neon_utils.socket_utils import b64_to_dict
 from ovos_bus_client.message import Message
+from pydantic import ValidationError
 from threading import RLock
 from ovos_utils.log import LOG
 
@@ -155,6 +158,14 @@ class MQWebsocketAPI(NeonAIClient):
                            "mq": {"routing_key": self.uid,
                                   "message_id": self.connection.
                                   create_unique_id()}}
+        with self._session_lock:
+            node_context = self._sessions.get(session_id, {}).get("node")
+        if node_context:
+            # Stamp the cached `node.hello` snapshot onto the outbound message
+            # so skills read capabilities synchronously from `context.node`
+            default_context["node"] = {
+                **node_context,
+                "site_id": self.get_session(session_id).get("site_id")}
         return {**message.context, **default_context}
 
     def _update_session_data(self, message: Message):
@@ -181,6 +192,36 @@ class MQWebsocketAPI(NeonAIClient):
                           {"session": session})
         run(self.send_to_client(message))
 
+    def _handle_node_hello(self, data: dict, session_id: str):
+        """
+        Cache the Node identity and capabilities advertised in a `node.hello`
+        message so outbound bus messages from this session can carry them in
+        `context.node`.
+        @param data: Decoded `node.hello` message from the client WebSocket
+        @param session_id: Session ID associated with the client connection
+        """
+        try:
+            hello = NodeHello(**{"context": {}, **data})
+        except ValidationError as e:
+            LOG.warning(f"Ignoring invalid node.hello from session "
+                        f"{session_id}: {e}")
+            return
+        if hello.data.node_id != session_id:
+            # The token-derived session_id is authoritative for identity; a
+            # client cannot claim another Node's ID via its hello payload
+            LOG.warning(f"node.hello node_id ({hello.data.node_id}) does not "
+                        f"match session ({session_id}); using session identity")
+        # model_dump() serializes capability keys back to wire strings; the
+        # validated model keys them by NodeNativeAction, which is not
+        # JSON-serializable in bus context
+        hello_data = hello.data.model_dump()
+        with self._session_lock:
+            if session_id in self._sessions:
+                self._sessions[session_id]["node"] = {
+                    "node_id": session_id,
+                    "node_name": hello_data["node_name"],
+                    "capabilities": hello_data["capabilities"]}
+
     def handle_client_input(self, data: dict, session_id: str):
         """
         Handle some client input data.
@@ -190,11 +231,49 @@ class MQWebsocketAPI(NeonAIClient):
         # Handle `Message.serialize` data sent over WS in addition to proper
         # dict representations
         data['msg_type'] = data.pop("type", data.get("msg_type"))
+        if data['msg_type'] == "node.hello":
+            self._handle_node_hello(data, session_id)
         message = Message(**data)
         message.context = self._get_message_context(message, session_id)
         message.context["session"] = self.get_session(session_id)
         # Send raw message, skipping any validation by iris
         self._send_message(message)
+
+    def handle_neon_response(self, channel, method, properties, body):
+        """
+        Dispatch `node.*` messages that `NeonAIClient` does not know about,
+        delegating everything else to its dispatcher unchanged.
+        """
+        # Peek at the msg_type; iris deserializes again on delegation. That
+        # cost is accepted to avoid duplicating its dispatch/timing logic here.
+        try:
+            response = b64_to_dict(body)
+        except Exception as e:
+            LOG.error(f"Failed to peek at MQ message: {e}")
+            response = None
+        if response and response.get("msg_type") == "node.invoke_native":
+            channel.basic_ack(delivery_tag=method.delivery_tag)
+            message = Message(response.get("msg_type"), response.get("data"),
+                              response.get("context"))
+            self.handle_node_invoke_native(message)
+        else:
+            super().handle_neon_response(channel, method, properties, body)
+
+    def handle_node_invoke_native(self, message: Message):
+        """
+        Forward a `node.invoke_native` request from a skill to the target Node.
+        The message is relayed as-is: the Node re-validates the requested
+        action and reports `not_supported` itself, which reaches the skill
+        faster than a hub-side drop would (drop = skill waits out its timeout).
+        @param message: `node.invoke_native` message from the bus
+        """
+        try:
+            run(self.send_to_client(message))
+        except KeyError:
+            LOG.error(f"node.invoke_native for unknown session: "
+                      f"{message.context.get('session', {}).get('session_id')}")
+        except Exception as e:
+            LOG.exception(e)
 
     def handle_klat_response(self, message: Message):
         """

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,4 +8,4 @@ neon-mq-connector~=0.7,>=0.8.1a3
 neon-utils>=1.14.1a1
 ovos-config~=0.0,>=0.0.12
 ovos-utils~=0.0,>=0.0.38
-neon-data-models~=0.0,>=0.0.2a11
+neon-data-models~=0.0,>=0.0.3a2

--- a/tests/test_mq_websocket_api.py
+++ b/tests/test_mq_websocket_api.py
@@ -24,9 +24,174 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import json
 import unittest
 
+from unittest.mock import AsyncMock, MagicMock, patch
 
-class TestMqServiceApi(unittest.TestCase):
-    from neon_hana.mq_websocket_api import MQWebsocketAPI
-    # TODO
+from neon_utils.socket_utils import dict_to_b64
+from ovos_bus_client.message import Message
+
+from neon_hana.mq_websocket_api import MQWebsocketAPI
+
+
+TEST_SESSION = "node-test"
+
+VALID_HELLO = {"msg_type": "node.hello",
+               "data": {"node_id": TEST_SESSION,
+                        "node_name": "Kitchen Phone",
+                        "capabilities": {"launch_camera_app": True,
+                                         "launch_sms_app": False}}}
+
+
+def _make_api() -> MQWebsocketAPI:
+    with patch("neon_hana.mq_websocket_api.NeonAIClient.__init__",
+               return_value=None):
+        api = MQWebsocketAPI({})
+    api.client_name = "test_client"
+    api._uid = "test-uid"
+    api._connection = MagicMock()
+    api._connection.create_unique_id.return_value = "test-mid"
+    api._send_message = MagicMock()
+    return api
+
+
+def _seed_session(api: MQWebsocketAPI, session_id: str = TEST_SESSION,
+                  site_id: str = "kitchen"):
+    socket = MagicMock()
+    socket.send_text = AsyncMock()
+    api._sessions[session_id] = {
+        "session": {"session_id": session_id, "site_id": site_id},
+        "socket": socket,
+        "user": {"user": {"username": "tester"}}}
+    return socket
+
+
+class TestNodeHello(unittest.TestCase):
+    def test_hello_caches_snapshot(self):
+        api = _make_api()
+        _seed_session(api)
+        api.handle_client_input(dict(VALID_HELLO), TEST_SESSION)
+        cached = api._sessions[TEST_SESSION]["node"]
+        self.assertEqual(cached["node_id"], TEST_SESSION)
+        self.assertEqual(cached["node_name"], "Kitchen Phone")
+        self.assertEqual(cached["capabilities"],
+                         {"launch_camera_app": True, "launch_sms_app": False})
+        # The hello is still forwarded to the bus
+        api._send_message.assert_called_once()
+
+    def test_hello_session_identity_is_authoritative(self):
+        api = _make_api()
+        _seed_session(api)
+        hello = {"msg_type": "node.hello",
+                 "data": {**VALID_HELLO["data"], "node_id": "someone-else"}}
+        api.handle_client_input(hello, TEST_SESSION)
+        # The token-derived session ID wins over the self-reported node_id
+        self.assertEqual(api._sessions[TEST_SESSION]["node"]["node_id"],
+                         TEST_SESSION)
+
+    def test_invalid_hello_ignored(self):
+        api = _make_api()
+        _seed_session(api)
+        for bad_data in ({},  # missing node_id
+                         {"node_id": TEST_SESSION,
+                          "node_name": "x" * 129}):  # name over cap
+            api.handle_client_input({"msg_type": "node.hello",
+                                     "data": bad_data}, TEST_SESSION)
+            self.assertNotIn("node", api._sessions[TEST_SESSION])
+
+    def test_hello_updates_on_repeat(self):
+        api = _make_api()
+        _seed_session(api)
+        api.handle_client_input(dict(VALID_HELLO), TEST_SESSION)
+        renamed = {"msg_type": "node.hello",
+                   "data": {**VALID_HELLO["data"], "node_name": "Den Phone"}}
+        api.handle_client_input(renamed, TEST_SESSION)
+        self.assertEqual(api._sessions[TEST_SESSION]["node"]["node_name"],
+                         "Den Phone")
+
+
+class TestNodeContextEnrichment(unittest.TestCase):
+    def test_context_includes_node_after_hello(self):
+        api = _make_api()
+        _seed_session(api)
+        api.handle_client_input(dict(VALID_HELLO), TEST_SESSION)
+        context = api._get_message_context(
+            Message("neon.audio_input", {}, {}), TEST_SESSION)
+        self.assertEqual(context["node"],
+                         {"node_id": TEST_SESSION,
+                          "node_name": "Kitchen Phone",
+                          "site_id": "kitchen",
+                          "capabilities": {"launch_camera_app": True,
+                                           "launch_sms_app": False}})
+
+    def test_context_without_hello_has_no_node(self):
+        api = _make_api()
+        _seed_session(api)
+        context = api._get_message_context(
+            Message("neon.audio_input", {}, {}), TEST_SESSION)
+        self.assertNotIn("node", context)
+
+
+class TestInvokeNativeDispatch(unittest.TestCase):
+    def _invoke_body(self, session_id: str = TEST_SESSION) -> bytes:
+        return dict_to_b64(
+            {"msg_type": "node.invoke_native",
+             "data": {"action": "launch_camera_app"},
+             "context": {"session": {"session_id": session_id}}})
+
+    def test_invoke_native_routed_to_client(self):
+        api = _make_api()
+        socket = _seed_session(api)
+        channel = MagicMock()
+        method = MagicMock()
+        method.delivery_tag = 1
+        api.handle_neon_response(channel, method, None, self._invoke_body())
+        channel.basic_ack.assert_called_once_with(delivery_tag=1)
+        socket.send_text.assert_called_once()
+        # `Message.serialize` uses `type` on the wire (see handle_client_input)
+        sent = json.loads(socket.send_text.call_args[0][0])
+        self.assertEqual(sent["type"], "node.invoke_native")
+        self.assertEqual(sent["data"]["action"], "launch_camera_app")
+
+    def test_other_messages_delegate_to_iris(self):
+        api = _make_api()
+        _seed_session(api)
+        body = dict_to_b64({"msg_type": "klat.response", "data": {},
+                            "context": {"session":
+                                        {"session_id": TEST_SESSION}}})
+        channel = MagicMock()
+        method = MagicMock()
+        with patch("neon_hana.mq_websocket_api.NeonAIClient."
+                   "handle_neon_response") as delegate:
+            api.handle_neon_response(channel, method, None, body)
+        delegate.assert_called_once_with(channel, method, None, body)
+        channel.basic_ack.assert_not_called()
+
+    def test_invoke_native_unknown_session_logged_not_raised(self):
+        api = _make_api()
+        message = Message("node.invoke_native",
+                          {"action": "launch_camera_app"},
+                          {"session": {"session_id": "node-gone"}})
+        # Must not raise; the skill's own timeout handles the failure path
+        api.handle_node_invoke_native(message)
+
+
+class TestInvokeNativeResponsePassthrough(unittest.TestCase):
+    def test_response_forwarded_to_bus(self):
+        api = _make_api()
+        _seed_session(api)
+        api.handle_client_input(
+            {"msg_type": "node.invoke_native.response",
+             "data": {"action": "launch_camera_app", "status": "success"},
+             "context": {}}, TEST_SESSION)
+        api._send_message.assert_called_once()
+        forwarded = api._send_message.call_args[0][0]
+        self.assertEqual(forwarded.msg_type, "node.invoke_native.response")
+        self.assertEqual(forwarded.data["status"], "success")
+        self.assertEqual(forwarded.context["session"]["session_id"],
+                         TEST_SESSION)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Server side of the Node native actions spec (companion to NeonGeckoCom/neon-data-models#35, now merged and consumed here as `neon-data-models>=0.0.3a2`).

- **`node.hello`**: HANA validates the message, caches the Node's identity/capability snapshot per session, and stamps it onto every outbound bus message as `context.node` — skills read capabilities synchronously with no extra round-trip. The token-derived session ID is authoritative: a mismatched self-reported `node_id` is logged and overridden, so a client cannot claim another Node's identity. Unknown capability keys are dropped at validation (a Node newer than the hub's schema must not fail its hello).
- **`node.invoke_native`**: a new `handle_neon_response` override dispatches these from the MQ response queue and relays them to the target Node's WebSocket. Everything else delegates to `NeonAIClient` unchanged. The message is relayed as-is: the Node re-validates the action and reports `not_supported` itself, which reaches the skill faster than a hub-side drop would.
- **`node.invoke_native.response`**: passes through the existing client-input path to the bus unchanged.
- `/node/v1/doc` signature updated so the new models appear in the generated docs.

## Testing

- 20 new unit tests in `tests/test_mq_websocket_api.py` (previously a TODO stub): hello caching/validation/identity, context enrichment, MQ dispatch/delegation, response passthrough. 57 pass locally.
- Verified end-to-end against a live Hub running this branch: WebSocket session as a real NODE-permission user — `node.hello` with a spoofed `node_id` and an unknown capability key, `context.node` confirmed stamped (string-keyed, unknown key dropped, session identity enforced) via response context echo; `node.invoke_native` published to HANA's MQ queue arrived on the client socket; response passthrough produced no server-side errors.