### PR TITLE
fix: drop null-valued profile keys from Node user_profiles context

### DIFF
--- a/neon_hana/mq_websocket_api.py
+++ b/neon_hana/mq_websocket_api.py
@@ -45,6 +45,26 @@ class ClientNotKnown(RuntimeError):
     """
 
 
+def _drop_null_values(profile: dict) -> dict:
+    """
+    Return a copy of `profile` with None-valued keys removed recursively.
+    Downstream profile merging (`neon_utils.configuration_utils`) only fills
+    defaults for ABSENT keys, so a key explicitly present as None can never
+    inherit a default. Sending a skeleton like `location: {"lat": None, ...}`
+    permanently masks the core's configured location and breaks skills that
+    require one (e.g. Wolfram Alpha 422s on `lat="None"`).
+    @param profile: dict user profile to filter
+    @return: profile copy without None-valued keys
+    """
+    filtered = {}
+    for key, value in profile.items():
+        if value is None:
+            continue
+        filtered[key] = _drop_null_values(value) if isinstance(value, dict) \
+            else value
+    return filtered
+
+
 class MQWebsocketAPI(NeonAIClient):
     def __init__(self, config: dict):
         """
@@ -138,7 +158,7 @@ class MQWebsocketAPI(NeonAIClient):
         with self._session_lock:
             config = dict(self._sessions.get(session_id, {}).get("user") or
                           self.user_config)
-        return config
+        return _drop_null_values(config)
 
     def _get_message_context(self, message: Message, session_id: str) -> dict:
         """

--- a/tests/test_mq_websocket_api.py
+++ b/tests/test_mq_websocket_api.py
@@ -177,6 +177,37 @@ class TestInvokeNativeDispatch(unittest.TestCase):
         api.handle_node_invoke_native(message)
 
 
+class TestUserProfileNullPruning(unittest.TestCase):
+    NULL_LOCATION_PROFILE = {
+        "user": {"username": "tester", "first_name": None},
+        "location": {"lat": None, "lng": None, "city": None, "state": None,
+                     "country": None, "tz": None, "utc": None},
+        "units": {"time": 12}}
+
+    def test_get_user_config_drops_null_values(self):
+        api = _make_api()
+        _seed_session(api)
+        api._sessions[TEST_SESSION]["user"] = dict(self.NULL_LOCATION_PROFILE)
+        config = api.get_user_config(TEST_SESSION)
+        # Explicit None keys would mask core-configured defaults downstream;
+        # absent keys inherit them
+        self.assertEqual(config["location"], {})
+        self.assertEqual(config["user"], {"username": "tester"})
+        self.assertEqual(config["units"], {"time": 12})
+        # The cached session profile is not mutated
+        self.assertIsNone(
+            api._sessions[TEST_SESSION]["user"]["location"]["lat"])
+
+    def test_message_context_carries_pruned_profile(self):
+        api = _make_api()
+        _seed_session(api)
+        api._sessions[TEST_SESSION]["user"] = dict(self.NULL_LOCATION_PROFILE)
+        context = api._get_message_context(
+            Message("neon.audio_input", {}, {}), TEST_SESSION)
+        self.assertEqual(context["user_profiles"][0]["location"], {})
+        self.assertEqual(context["username"], "tester")
+
+
 class TestInvokeNativeResponsePassthrough(unittest.TestCase):
     def test_response_forwarded_to_bus(self):
         api = _make_api()


### PR DESCRIPTION
## Summary
- The Node WS bridge (`MQWebsocketAPI`) seeds its user profile from neon_iris, whose default user config ships every `location` key present but null. That skeleton is stamped into `user_profiles` on every Node message.
- Downstream profile merging (`neon_utils.configuration_utils.dict_update_keys`) only fills defaults for **absent** keys, so present-but-null keys can never inherit the core's configured location — skills that need one break (e.g. skill-fallback_wolfram_alpha serializes `lat=None` to the string `"None"` and gets a 422 from the `/proxy/wolframalpha` endpoint).
- Fix: prune None-valued keys recursively in `get_user_config()` so Node messages carry those keys as absent, letting the core heal them from defaults.

## Test plan
- Two new unit tests: pruning in `get_user_config` (including no mutation of the cached session profile) and the pruned profile reaching `user_profiles` in the outbound message context.
- `pytest tests/test_mq_websocket_api.py`: 12 passed. Full suite: 58 passed, 1 pre-existing failure (`test_auth.py::TestClientManager::test_check_auth_request`, fails identically on clean `dev`).
- Root-caused against a live hub: bus snoop showed `neon_node_websocket` messages carrying `location: {"lat": null, ...}`, which reproduced the Wolfram 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)